### PR TITLE
Surface real error details from callNodeRed

### DIFF
--- a/lib/utils.mjs
+++ b/lib/utils.mjs
@@ -20,9 +20,40 @@ export async function callNodeRed(method, path, data = null, config) {
     const response = await axios({ method, url, headers, data });
     return response.data;
   } catch (error) {
-    const message = error.response?.data || error.message;
-    throw new Error(`Node-RED API error: ${message}`);
+    throw new Error(`Node-RED API error: ${formatAxiosError(error, method, url)}`);
   }
+}
+
+/**
+ * Build a human-readable error string from an axios error, including
+ * connection code, HTTP status, response body, and the target URL so the
+ * user can tell *which* request failed and *why*.
+ *
+ * Previously this was a single `error.response?.data || error.message`
+ * expression, which swallowed crucial details: connection errors have no
+ * `error.response`, some Node/axios versions emit an empty `error.message`
+ * on ECONNREFUSED, and object response bodies stringify to "[object Object]".
+ *
+ * @param {Error} error - axios error
+ * @param {string} method - HTTP method used for the failed request
+ * @param {string} url - full target URL
+ * @returns {string}
+ */
+function formatAxiosError(error, method, url) {
+  const parts = [];
+  if (error.code) parts.push(error.code);
+  if (error.response?.status) {
+    const statusText = error.response.statusText ? ` ${error.response.statusText}` : '';
+    parts.push(`HTTP ${error.response.status}${statusText}`);
+  }
+  const body = error.response?.data;
+  if (body !== undefined && body !== null && body !== '') {
+    parts.push(typeof body === 'string' ? body : JSON.stringify(body));
+  } else if (error.message) {
+    parts.push(error.message);
+  }
+  if (parts.length === 0) parts.push('unknown error');
+  return `${parts.join(' — ')} (${method.toUpperCase()} ${url})`;
 }
 
 /**


### PR DESCRIPTION
## Problem

`lib/utils.mjs:callNodeRed` builds its thrown error with:

```js
const message = error.response?.data || error.message;
throw new Error(`Node-RED API error: ${message}`);
```

This silently drops the information users need to diagnose real failures:

1. **Connection-level errors** (ECONNREFUSED, DNS failures, timeouts) have no `error.response`, so the fallback is `error.message`. Some axios + Node combinations emit an **empty string** for `error.message` on ECONNREFUSED, and `"" || undefined` produces an empty interpolation. Users see `Node-RED API error: ` with nothing after the colon.
2. **Object response bodies** (which Node-RED's admin API does return for some failures) stringify to `[object Object]` via the template literal.
3. **Neither the URL nor the method is included**, so when a user has multiple tools in flight, there's no way to know which call failed or whether it hit the expected host.

I burned several hours debugging a misconfigured `NODE_RED_URL` because of this — the error message literally could not tell me that the wrapper was hitting `http://localhost:1880` instead of my real Node-RED host.

## Fix

Extract the formatter into a helper (`formatAxiosError`) that builds a descriptive message from whichever axios fields are actually populated: connection code, HTTP status + statusText, stringified response body (object or string), or `error.message` as a last resort — followed by the method and URL.

## Before / after

```
# Before (ECONNREFUSED case)
Node-RED API error: 

# After
Node-RED API error: ECONNREFUSED — connect ECONNREFUSED 127.0.0.1:1 (GET http://127.0.0.1:1/flows)
```

```
# Before (401 with text body)
Node-RED API error: Unauthorized

# After
Node-RED API error: HTTP 401 Unauthorized — Unauthorized (GET http://localhost:1880/flows)
```

## Testing

Verified locally against a dead port (ECONNREFUSED) — message now contains the code, underlying axios description, method, and URL.

No new dependencies, no API surface change.